### PR TITLE
Rename progress XML attribute to prevent clashing with diffrent modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Croller croller.setOnCrollerChangeListener(new OnCrollerChangeListener() {
 XML Attribute | Java set method | Functionality
 ------------ | ------------- | ------------- 
 anticlockwise | setAntiClockwise(boolean anticlockwise) | Set the direction of rotation
-progress | setProgress(int progress) | Set the current progress of the seekbar
+start_progress | setProgress(int progress) | Set the current progress of the seekbar
 label | setLabel(String str) | Set the label
 label_size | setLabelSize(int size) | Set the label size
 label_color | setLabelColor(int color) | Set the label color

--- a/croller/src/main/java/com/sdsmdg/harjot/crollerTest/Croller.java
+++ b/croller/src/main/java/com/sdsmdg/harjot/crollerTest/Croller.java
@@ -123,7 +123,7 @@ public class Croller extends View {
         final int N = a.getIndexCount();
         for (int i = 0; i < N; ++i) {
             int attr = a.getIndex(i);
-            if (attr == R.styleable.Croller_progress) {
+            if (attr == R.styleable.Croller_start_progress) {
                 setProgress(a.getInt(attr, 1));
             } else if (attr == R.styleable.Croller_label) {
                 setLabel(a.getString(attr));

--- a/croller/src/main/res/values/attrs.xml
+++ b/croller/src/main/res/values/attrs.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <declare-styleable name="Croller">
-        <attr name="progress" format="integer" />
+        <attr name="start_progress" format="integer" />
         <attr name="label" format="string" />
         <attr name="back_circle_color" format="color" />
         <attr name="main_circle_color" format="color" />


### PR DESCRIPTION
When using build tools 3.2.1 Android Studio threw an error `Android resource compilation failed. duplicate value for resource 'attr/progress'`, which means the library as it stands is not compatible with a diffrent module. Renaming the `progress` attr to `start_progress` fixed the issue.